### PR TITLE
[ new ] Add `parse` functions to `FilePath` and `AnyFile`

### DIFF
--- a/src/Data/FilePath.idr
+++ b/src/Data/FilePath.idr
@@ -378,6 +378,15 @@ namespace RelPath
     -> Path Rel
   fromString s = fromJust (parse s)
 
+||| A quite strict function for parsing absolute paths.
+||| This only accepts valid file bodies, so no doubling
+||| of path separators or bodies starting with or ending
+||| on whitespace. Sorry.
+public export
+parse : String -> Maybe FilePath
+parse str = FP <$> AbsPath.parse str
+        <|> FP <$> RelPath.parse str
+
 --------------------------------------------------------------------------------
 --          Tests
 --------------------------------------------------------------------------------

--- a/src/Data/FilePath/File.idr
+++ b/src/Data/FilePath/File.idr
@@ -182,6 +182,15 @@ Interpolation AnyFile where interpolate (AF p) = interpolate p
 
 namespace AnyFile
 
+  ||| A quite strict function for parsing absolute paths.
+  ||| This only accepts valid file bodies, so no doubling
+  ||| of path separators or bodies starting with or ending
+  ||| on whitespace. Sorry.
+  public export
+  parse : String -> Maybe AnyFile
+  parse str = AF <$> AbsFile.parse str
+          <|> AF <$> RelFile.parse str
+
   ||| Try and split a path into parent directory and
   ||| file/directory name.
   public export


### PR DESCRIPTION
Correct me if I'm wrong, but the most useful types *at the input* of a system are existentials like `FilePath` and `AnyFile`, but they don't have `parse` functions. I propose to add them.