### PR TITLE
[ new ] add Windows support

### DIFF
--- a/src/Data/FilePath.idr
+++ b/src/Data/FilePath.idr
@@ -104,7 +104,7 @@ network sv sh = PAbs (UNC sv sh) [<]
 export
 isAbsolute : Path t -> Bool
 isAbsolute (PAbs _ _) = True
-isAbsolute (PRel _) = False
+isAbsolute (PRel _)   = False
 
 ||| Tries to extract the basename from a path.
 export %inline
@@ -389,7 +389,7 @@ namespace AbsPath
       parseBody t =
         let ps := split (\c => c == '/' || c == '\\') t
          in (Lin <><) <$> traverse fromChars (forget ps)
-    
+
       parseUNCBody : List Char -> Maybe (Path Abs)
       parseUNCBody t = case split (\c => c == '/' || c == '\\') t of
         [] ::: _        => Nothing
@@ -401,7 +401,7 @@ namespace AbsPath
       parseUnix ('/' :: t)  = PAbs Unix <$> parseBody t
       parseUnix ('\\' :: t) = PAbs Unix <$> parseBody t
       parseUnix _           = Nothing
-      
+
       parseDisk : List Char -> Maybe (Path Abs)
       parseDisk (d :: ':' :: '/' :: t)  = PAbs (Disk d) <$> parseBody t
       parseDisk (d :: ':' :: '\\' :: t) = PAbs (Disk d) <$> parseBody t

--- a/src/Data/FilePath/Body.idr
+++ b/src/Data/FilePath/Body.idr
@@ -4,6 +4,7 @@ module Data.FilePath.Body
 
 import Data.List
 import Data.List1
+import System.Info
 
 %default total
 
@@ -36,10 +37,10 @@ and {x = False} {y = _}     _ _ impossible
 --          Constants
 --------------------------------------------------------------------------------
 
-||| The Unix path separator
+||| The platform dependent path separator
 public export %inline
 Sep : Char
-Sep = '/'
+Sep = if isWindows then '\\' else '/'
 
 --------------------------------------------------------------------------------
 --          BodyChar
@@ -49,8 +50,9 @@ Sep = '/'
 ||| We don't allow path separators and control characters in path bodies.
 public export
 isBodyChar : Char -> Bool
-isBodyChar '/' = False
-isBodyChar c   = not (isControl c)
+isBodyChar '/'  = False
+isBodyChar '\\' = False
+isBodyChar c    = not (isControl c)
 
 public export
 0 BodyChar : Char -> Type

--- a/src/Data/FilePath/File.idr
+++ b/src/Data/FilePath/File.idr
@@ -127,8 +127,8 @@ namespace AbsFile
   public export
   parse : String -> Maybe (File Abs)
   parse s = case AbsPath.parse s of
-    Just (PAbs $ sx :< x) => Just $ MkF (PAbs sx) x
-    _                     => Nothing
+    Just (PAbs at $ sx :< x) => Just $ MkF (PAbs at sx) x
+    _                        => Nothing
 
   public export
   fromString :


### PR DESCRIPTION
This is an implementation of the changes I proposed in #19.

There should probably be proper tests for parsing the different kinds of paths, but I don't know how to write them.

A few things to note:
* I'm not sure what `Data.FilePath.Body.Sep` is for, as it wasn't used anywhere. I've made it platform dependent, and used it in the `Interpolation` implementation.
* Apparently, drive relative paths are a thing, e.g. `\some\path` which, if the current drive is `C:`, would be interpreted as `C:\some\path`. These are currently parsed as absolute Unix paths, but I've never seen them used so I'm not sure it's worth it to try to distinguish them somehow. (or if it's even necessary)
* Additionally, it appears there are "drive's current directory relative" paths, e.g. `D:some\path` (no `\` after the `:`), which is a path relative to the working directory on the `D:` drive, even if current drive is a different one. Apparently Windows shells track a separate working directory for each drive. Again, I've never seen this, so I haven't added support for it.