### PR TITLE
[ fix ] temporarily use unix file separators

### DIFF
--- a/src/Data/FilePath/Body.idr
+++ b/src/Data/FilePath/Body.idr
@@ -40,7 +40,7 @@ and {x = False} {y = _}     _ _ impossible
 ||| The platform dependent path separator
 public export %inline
 Sep : Char
-Sep = if isWindows then '\\' else '/'
+Sep = '/'
 
 --------------------------------------------------------------------------------
 --          BodyChar


### PR DESCRIPTION
@elseLuna unfortunately, chaning the `Sep` constant to depend on the current OS is a breaking change that renders this library unusable on certain backends. I'll temporarily revert this until I can come up with a better solution.