### PR TITLE
[ refactor ] refine `AbsType` constructor types

### DIFF
--- a/test/src/FilePathProps.idr
+++ b/test/src/FilePathProps.idr
@@ -29,8 +29,12 @@ relDir : Gen (Path Rel)
 relDir = PRel . (Lin <><) <$> list (linear 0 6) body
 
 export
+driveLetter : Gen DriveLetter
+driveLetter = fromMaybe 'C' . parse <$> choice [upper, lower]
+
+export
 absType : Gen AbsType
-absType = choice [pure Unix, map Disk upper, [| UNC body' body' |]]
+absType = choice [pure Unix, map Disk driveLetter, [| UNC body body |]]
 
 export
 absDir : Gen (Path Abs)


### PR DESCRIPTION
I wasn't sure what to call this but went with "refactor". Would you say that's correct?

The main change here is to restrict `Disk` to only accept valid drive letters, but I also replaced `String` with `Body` in `UNC`. UNC server names could probably be refined more, but `Body` is a good first step.

In the definition of `DriveLetter` I used `isAlpha letter === True`, to match how `BodyChars` is defined, but I would normally use `Data.So` for this. Is there a reason `BodyChars` doesn't use `So`?